### PR TITLE
More flexible composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "description": "reference bundle based on contentBundle of open orchestra",
     "minimum-stability": "dev",
     "require": {
-        "open-orchestra/open-orchestra-model-interface": "v0.1.3",
-        "open-orchestra/open-orchestra-model-bundle": "v0.1.3"
+        "open-orchestra/open-orchestra-model-interface": ">=0.1.3",
+        "open-orchestra/open-orchestra-model-bundle": ">=0.1.3"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Allow for greater versions of open orchestra. The main project should then determine the exact version to use.
