### PR TITLE
update use statement for orchestra 0.1.4

### DIFF
--- a/ReferenceBundle/Repository/ReferenceRepository.php
+++ b/ReferenceBundle/Repository/ReferenceRepository.php
@@ -3,7 +3,7 @@
 namespace Itkg\ReferenceBundle\Repository;
 
 use Doctrine\ODM\MongoDB\DocumentRepository;
-use OpenOrchestra\ModelBundle\Repository\FieldAutoGenerableRepositoryInterface;
+use OpenOrchestra\ModelInterface\Repository\FieldAutoGenerableRepositoryInterface;
 use Itkg\ReferenceInterface\Repository\ReferenceRepositoryInterface;
 use OpenOrchestra\BaseBundle\Context\CurrentSiteIdInterface;
 use Doctrine\ODM\MongoDB\Query\Builder;

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "description": "reference bundle based on contentBundle of open orchestra",
     "minimum-stability": "dev",
     "require": {
-        "open-orchestra/open-orchestra-model-interface": ">=0.1.3",
-        "open-orchestra/open-orchestra-model-bundle": ">=0.1.3"
+        "open-orchestra/open-orchestra-model-interface": ">=0.1.4",
+        "open-orchestra/open-orchestra-model-bundle": ">=0.1.4"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
The FieldAutoGenerableRepositoryInterface was changed from the model bundle to the model interface package in orchestra 0.1.4.

This change requires to use orchestra 0.1.4 so i have update the composer configuration in order to avoid upgrading the reference-bundle by mistake.
