### PR TITLE
translate table header as in orchestra 0.2.5

### DIFF
--- a/ReferenceApiBundle/Transformer/ReferenceCollectionTransformer.php
+++ b/ReferenceApiBundle/Transformer/ReferenceCollectionTransformer.php
@@ -32,8 +32,6 @@ class ReferenceCollectionTransformer extends AbstractTransformer
             ));
         }
 
-        $facade->addLink('_translate', $this->generateRoute('open_orchestra_api_translate'));
-
         return $facade;
     }
 

--- a/ReferenceApiBundle/Transformer/ReferenceTransformer.php
+++ b/ReferenceApiBundle/Transformer/ReferenceTransformer.php
@@ -49,8 +49,6 @@ class ReferenceTransformer extends AbstractTransformer
 
         $facade->addLink('_language_list', $this->generateRoute('open_orchestra_api_parameter_languages_show'));
 
-        $facade->addLink('_translate', $this->generateRoute('open_orchestra_api_translate'));
-
        return $facade;
     }
 

--- a/ReferenceBundle/Resources/views/AdministrationPanel/reference_types.html.twig
+++ b/ReferenceBundle/Resources/views/AdministrationPanel/reference_types.html.twig
@@ -3,6 +3,8 @@
         id="nav-reference_types"
         data-url="{{ path('open_orchestra_api_reference_type_list') }}"
         data-displayed-elements="reference_type_id, name"
+        data-translated-header="{{ 'itkg_reference_bundle.form.reference_type.id'|trans }},
+                {{ 'itkg_reference_bundle.form.reference_type.name'|trans }}"
         title="{{ 'itkg_reference_bundle.left_menu.administration.reference_type.list'|trans }}"
         >
     {{ 'itkg_reference_bundle.left_menu.administration.reference_type.list'|trans }}

--- a/ReferenceBundle/Resources/views/Tree/reference-macros.html.twig
+++ b/ReferenceBundle/Resources/views/Tree/reference-macros.html.twig
@@ -9,6 +9,9 @@
                 href="#references_{{referenceType.referenceTypeId}}/list"
                 data-url="{{ path('open_orchestra_api_reference_list', {'reference_type': referenceType.referenceTypeId}) }}"
                 data-displayed-elements="reference_id, name, language"
+                data-translated-header="{{ 'open_orchestra_backoffice.table.reference_type.reference_id'|trans }},
+                {{ 'open_orchestra_backoffice.table.reference_type.name'|trans }},
+                {{ 'open_orchestra_backoffice.table.reference_type.language'|trans }}"
             >
                 {{ referenceType.names| trans_choose }}
             </a>


### PR DESCRIPTION
There is no more translateController in orchestra 0.2.4+, this PR uses the new way of doing things.
