### PR TITLE
[FEATURE] Replace LeftMenu by NavigationPanel

### DIFF
--- a/ReferenceBundle/NavigationPanel/Strategies/ReferenceTypeForReferencePanelStrategy.php
+++ b/ReferenceBundle/NavigationPanel/Strategies/ReferenceTypeForReferencePanelStrategy.php
@@ -1,14 +1,14 @@
 <?php
-namespace Itkg\ReferenceBundle\LeftPanel\Strategies;
+namespace Itkg\ReferenceBundle\NavigationPanel\Strategies;
 
 use Itkg\ReferenceInterface\Repository\ReferenceTypeRepositoryInterface;
-use OpenOrchestra\Backoffice\LeftPanel\Strategies\AbstractLeftPanelStrategy;
+use OpenOrchestra\Backoffice\NavigationPanel\Strategies\AbstractNavigationPanelStrategy;
 
 /**
  * Class ReferenceTypeForReferencePanelStrategy
  */
 
-class ReferenceTypeForReferencePanelStrategy extends AbstractLeftPanelStrategy
+class ReferenceTypeForReferencePanelStrategy extends AbstractNavigationPanelStrategy
 {
     const ROLE_ACCESS_REFERENCE_TYPE_FOR_REFERENCE = 'ROLE_ACCESS_REFERENCE_TYPE_FOR_REFERENCE';
 
@@ -45,7 +45,7 @@ class ReferenceTypeForReferencePanelStrategy extends AbstractLeftPanelStrategy
      */
     public function getParent()
     {
-        return self::EDITORIAL;
+        return 'editorial';
     }
 
     /**

--- a/ReferenceBundle/NavigationPanel/Strategies/ReferenceTypePanelStrategy.php
+++ b/ReferenceBundle/NavigationPanel/Strategies/ReferenceTypePanelStrategy.php
@@ -1,13 +1,12 @@
 <?php
 
-namespace Itkg\ReferenceBundle\LeftPanel\Strategies;
+namespace Itkg\ReferenceBundle\NavigationPanel\Strategies;
 
-use OpenOrchestra\Backoffice\LeftPanel\Strategies\AdministrationPanelStrategy;
+use OpenOrchestra\Backoffice\NavigationPanel\Strategies\AdministrationPanelStrategy;
 
 /**
  * Class ReferenceTypePanelStrategy
  */
-
 class ReferenceTypePanelStrategy extends AdministrationPanelStrategy
 {
     /**
@@ -17,15 +16,10 @@ class ReferenceTypePanelStrategy extends AdministrationPanelStrategy
      * @param int    $weight
      * @param string $parent
      */
-
-    protected $path;
-
-    public function __construct($name, $role, $bundle, $weight = 0, $parent = self::ADMINISTRATION)
+    public function __construct($name, $role, $bundle, $weight = 0, $parent = 'administration')
     {
-        $this->name = $name;
-        $this->role = $role;
-        $this->weight = $weight;
-        $this->parent = $parent;
+        parent::__construct($name, $role, $weight, $parent);
+
         $this->bundle = $bundle;
     }
 

--- a/ReferenceBundle/Resources/config/services.yml
+++ b/ReferenceBundle/Resources/config/services.yml
@@ -5,8 +5,8 @@ parameters:
     itkg_reference.document.reference_type.class : Itkg\ReferenceBundle\Document\ReferenceType
     itkg_reference.document.reference.class : Itkg\ReferenceBundle\Document\Reference
 
-    itkg_reference.left_panel.reference_types.class : Itkg\ReferenceBundle\LeftPanel\Strategies\ReferenceTypePanelStrategy
-    itkg_reference.left_panel.reference.class : Itkg\ReferenceBundle\LeftPanel\Strategies\ReferenceTypeForReferencePanelStrategy
+    itkg_reference.navigation_panel.reference_types.class : Itkg\ReferenceBundle\LeftPanel\Strategies\ReferenceTypePanelStrategy
+    itkg_reference.navigation_panel.reference.class : Itkg\ReferenceBundle\LeftPanel\Strategies\ReferenceTypeForReferencePanelStrategy
 
     itkg_reference.manager.reference_type.class : Itkg\ReferenceBundle\Manager\ReferenceTypeManager
     itkg_reference.manager.reference.class : Itkg\ReferenceBundle\Manager\ReferenceManager
@@ -31,22 +31,22 @@ services:
 
 ## MENU STRATEGIES ##
 
-    itkg_reference.left_panel.reference_types:
-        class: %itkg_reference.left_panel.reference_types.class%
+    itkg_reference.navigation_panel.reference_types:
+        class: %itkg_reference.navigation_panel.reference_types.class%
         arguments:
             - reference_types
             - ROLE_ACCESS_REFERENCE_TYPE
             - ItkgReferenceBundle
             - 12
         tags:
-            - { name: open_orchestra_backoffice.left_panel.strategy }
+            - { name: open_orchestra_backoffice.navigation_panel.strategy }
 
-    itkg_reference.left_panel.reference:
-        class: %itkg_reference.left_panel.reference.class%
+    itkg_reference.navigation_panel.reference:
+        class: %itkg_reference.navigation_panel.reference.class%
         arguments:
             - @itkg_reference.repository.reference_type
         tags:
-            - { name: open_orchestra_backoffice.left_panel.strategy }
+            - { name: open_orchestra_backoffice.navigation_panel.strategy }
 
 ## MANAGER ##
 

--- a/ReferenceBundle/Resources/translations/messages.en.yml
+++ b/ReferenceBundle/Resources/translations/messages.en.yml
@@ -1,5 +1,5 @@
 itkg_reference_bundle:
-    left_menu:
+    navigation_panel:
         administration:
             reference_type:
                 list: Reference type

--- a/ReferenceBundle/Resources/translations/messages.fr.yml
+++ b/ReferenceBundle/Resources/translations/messages.fr.yml
@@ -1,5 +1,5 @@
 itkg_reference_bundle:
-    left_menu:
+    navigation_panel:
         administration:
             reference_type:
                 list: Types de Référence

--- a/ReferenceBundle/Resources/views/AdministrationPanel/reference_types.html.twig
+++ b/ReferenceBundle/Resources/views/AdministrationPanel/reference_types.html.twig
@@ -5,7 +5,7 @@
         data-displayed-elements="reference_type_id, name"
         data-translated-header="{{ 'itkg_reference_bundle.form.reference_type.id'|trans }},
                 {{ 'itkg_reference_bundle.form.reference_type.name'|trans }}"
-        title="{{ 'itkg_reference_bundle.left_menu.administration.reference_type.list'|trans }}"
+        title="{{ 'itkg_reference_bundle.navigation_panel.administration.reference_type.list'|trans }}"
         >
-    {{ 'itkg_reference_bundle.left_menu.administration.reference_type.list'|trans }}
+    {{ 'itkg_reference_bundle.navigation_panel.administration.reference_type.list'|trans }}
 </a>

--- a/ReferenceBundle/Resources/views/EditorialPanel/showReferenceTypeForReference.html.twig
+++ b/ReferenceBundle/Resources/views/EditorialPanel/showReferenceTypeForReference.html.twig
@@ -1,7 +1,7 @@
 {% extends 'OpenOrchestraBackofficeBundle:Tree:tree.html.twig' %}
 {% import "ItkgReferenceBundle:Tree:reference-macros.html.twig" as reference_macros %}
 
-{% set name = 'itkg_reference_bundle.left_menu.editorial.references'|trans %}
+{% set name = 'itkg_reference_bundle.navigation_panel.editorial.references'|trans %}
 
 {% block menu %}
     {{ reference_macros.menu_reference_types_for_reference(referenceTypes) }}


### PR DESCRIPTION
Since OpenOrchestra 0.3.2, LeftMenu is replaced by NavigationPanel.
